### PR TITLE
Django 1.6 support, Travis, message chunking

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,30 @@
+language: python
+python:
+  - 2.6
+  - 2.7
+  - 3.3
+  - pypy
+
+env:
+  - DJANGO_VERSION=1.3.7
+  - DJANGO_VERSION=1.4.10
+  - DJANGO_VERSION=1.5.5
+  - DJANGO_VERSION=1.6.1
+
+matrix:
+  exclude:
+    - python: 3.3
+      env: DJANGO_VERSION=1.3.7
+    - python: 3.3
+      env: DJANGO_VERSION=1.4.10
+    - python: pypy
+      env: DJANGO_VERSION=1.3.7
+    - python: pypy
+      env: DJANGO_VERSION=1.4.10
+
+install:
+  - pip install Django==$DJANGO_VERSION
+  - pip install -r requirements.txt
+
+
+script: python setup.py test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,29 +1,146 @@
 language: python
-python:
-  - 2.6
-  - 2.7
-  - 3.3
-  - pypy
 
-env:
-  - DJANGO_VERSION=1.3.7
-  - DJANGO_VERSION=1.4.10
-  - DJANGO_VERSION=1.5.5
-  - DJANGO_VERSION=1.6.1
-
+# The current build matrix may be described as follows:
+#
+#   build := (Python version, Django version, Celery version)
+#
+# where
+#
+#   2.6 <= Python version <= 3.3 + PyPy
+#   1.3 <= Django version <= 1.6
+#   2.3 <= Celery version <= 3.1
+#
+# We skip Celery 2.5 since it doesn't introduce any relevant features
+# and the number of build variants is big enough already.
+#
+# Python 3.3 and PyPy are only supported by Django 1.5+.
+# Python 3.3 is only supported by Celery 2.4+.
+#
+# For Celery < 3.1, we additionally need to install django-celery.
+#
+# Since this kind of build matrix is difficult to encode in a .travis.yml
+# file we just present an unrolled version here.
 matrix:
-  exclude:
+  include:
+    # Python 2.6: Django 1.2 to 1.6, Celery 2.3 to 3.1
+    - python: 2.6
+      env: INSTALL="Django>=1.2,<1.3 celery>=2.3,<2.4 django-celery django-override-settings"
+    - python: 2.6
+      env: INSTALL="Django>=1.2,<1.3 celery>=2.4,<2.5 django-celery django-override-settings"
+    - python: 2.6
+      env: INSTALL="Django>=1.2,<1.3 celery>=3.0,<3.1 django-celery django-override-settings"
+    - python: 2.6
+      env: INSTALL="Django>=1.2,<1.3 celery>=3.1,<3.2 django-override-settings"
+    - python: 2.6
+      env: INSTALL="Django>=1.3,<1.4 celery>=2.3,<2.4 django-celery django-override-settings"
+    - python: 2.6
+      env: INSTALL="Django>=1.3,<1.4 celery>=2.4,<2.5 django-celery django-override-settings"
+    - python: 2.6
+      env: INSTALL="Django>=1.3,<1.4 celery>=3.0,<3.1 django-celery django-override-settings"
+    - python: 2.6
+      env: INSTALL="Django>=1.3,<1.4 celery>=3.1,<3.2 django-override-settings"
+    - python: 2.6
+      env: INSTALL="Django>=1.4,<1.5 celery>=2.3,<2.4 django-celery"
+    - python: 2.6
+      env: INSTALL="Django>=1.4,<1.5 celery>=2.4,<2.5 django-celery"
+    - python: 2.6
+      env: INSTALL="Django>=1.4,<1.5 celery>=3.0,<3.1 django-celery"
+    - python: 2.6
+      env: INSTALL="Django>=1.4,<1.5 celery>=3.1,<3.2"
+    - python: 2.6
+      env: INSTALL="Django>=1.5,<1.6 celery>=2.3,<2.4 django-celery"
+    - python: 2.6
+      env: INSTALL="Django>=1.5,<1.6 celery>=2.4,<2.5 django-celery"
+    - python: 2.6
+      env: INSTALL="Django>=1.5,<1.6 celery>=3.0,<3.1 django-celery"
+    - python: 2.6
+      env: INSTALL="Django>=1.5,<1.6 celery>=3.1,<3.2"
+    - python: 2.6
+      env: INSTALL="Django>=1.6,<1.7 celery>=2.3,<2.4 django-celery"
+    - python: 2.6
+      env: INSTALL="Django>=1.6,<1.7 celery>=2.4,<2.5 django-celery"
+    - python: 2.6
+      env: INSTALL="Django>=1.6,<1.7 celery>=3.0,<3.1 django-celery"
+    - python: 2.6
+      env: INSTALL="Django>=1.6,<1.7 celery>=3.1,<3.2"
+    
+    # Python 2.7: Django 1.2 to 1.6, Celery 2.3 to 3.1
+    - python: 2.7
+      env: INSTALL="Django>=1.2,<1.3 celery>=2.3,<2.4 django-celery django-override-settings"
+    - python: 2.7
+      env: INSTALL="Django>=1.2,<1.3 celery>=2.4,<2.5 django-celery django-override-settings"
+    - python: 2.7
+      env: INSTALL="Django>=1.2,<1.3 celery>=3.0,<3.1 django-celery django-override-settings"
+    - python: 2.7
+      env: INSTALL="Django>=1.2,<1.3 celery>=3.1,<3.2 django-override-settings"
+    - python: 2.7
+      env: INSTALL="Django>=1.3,<1.4 celery>=2.3,<2.4 django-celery django-override-settings"
+    - python: 2.7
+      env: INSTALL="Django>=1.3,<1.4 celery>=2.4,<2.5 django-celery django-override-settings"
+    - python: 2.7
+      env: INSTALL="Django>=1.3,<1.4 celery>=3.0,<3.1 django-celery django-override-settings"
+    - python: 2.7
+      env: INSTALL="Django>=1.3,<1.4 celery>=3.1,<3.2 django-override-settings"
+    - python: 2.7
+      env: INSTALL="Django>=1.4,<1.5 celery>=2.3,<2.4 django-celery"
+    - python: 2.7
+      env: INSTALL="Django>=1.4,<1.5 celery>=2.4,<2.5 django-celery"
+    - python: 2.7
+      env: INSTALL="Django>=1.4,<1.5 celery>=3.0,<3.1 django-celery"
+    - python: 2.7
+      env: INSTALL="Django>=1.4,<1.5 celery>=3.1,<3.2"
+    - python: 2.7
+      env: INSTALL="Django>=1.5,<1.6 celery>=2.3,<2.4 django-celery"
+    - python: 2.7
+      env: INSTALL="Django>=1.5,<1.6 celery>=2.4,<2.5 django-celery"
+    - python: 2.7
+      env: INSTALL="Django>=1.5,<1.6 celery>=3.0,<3.1 django-celery"
+    - python: 2.7
+      env: INSTALL="Django>=1.5,<1.6 celery>=3.1,<3.2"
+    - python: 2.7
+      env: INSTALL="Django>=1.6,<1.7 celery>=2.3,<2.4 django-celery"
+    - python: 2.7
+      env: INSTALL="Django>=1.6,<1.7 celery>=2.4,<2.5 django-celery"
+    - python: 2.7
+      env: INSTALL="Django>=1.6,<1.7 celery>=3.0,<3.1 django-celery"
+    - python: 2.7
+      env: INSTALL="Django>=1.6,<1.7 celery>=3.1,<3.2"
+      
+    # Python 3.3: Django 1.5 to 1.6, Celery 2.4 to 3.1
     - python: 3.3
-      env: DJANGO_VERSION=1.3.7
+      env: INSTALL="Django>=1.5,<1.6 celery>=2.4,<2.5 django-celery"
     - python: 3.3
-      env: DJANGO_VERSION=1.4.10
+      env: INSTALL="Django>=1.5,<1.6 celery>=3.0,<3.1 django-celery"
+    - python: 3.3
+      env: INSTALL="Django>=1.5,<1.6 celery>=3.1,<3.2"
+    - python: 3.3
+      env: INSTALL="Django>=1.6,<1.7 celery>=2.4,<2.5 django-celery"
+    - python: 3.3
+      env: INSTALL="Django>=1.6,<1.7 celery>=3.0,<3.1 django-celery"
+    - python: 3.3
+      env: INSTALL="Django>=1.6,<1.7 celery>=3.1,<3.2"
+      
+    # PyPy: Django 1.5 to 1.6, Celery 2.3 to 3.1
     - python: pypy
-      env: DJANGO_VERSION=1.3.7
+      env: INSTALL="Django>=1.5,<1.6 celery>=2.3,<2.4 django-celery"
     - python: pypy
-      env: DJANGO_VERSION=1.4.10
+      env: INSTALL="Django>=1.5,<1.6 celery>=2.4,<2.5 django-celery"
+    - python: pypy
+      env: INSTALL="Django>=1.5,<1.6 celery>=3.0,<3.1 django-celery"
+    - python: pypy
+      env: INSTALL="Django>=1.5,<1.6 celery>=3.1,<3.2"
+    - python: pypy
+      env: INSTALL="Django>=1.6,<1.7 celery>=2.3,<2.4 django-celery"
+    - python: pypy
+      env: INSTALL="Django>=1.6,<1.7 celery>=2.4,<2.5 django-celery"
+    - python: pypy
+      env: INSTALL="Django>=1.6,<1.7 celery>=3.0,<3.1 django-celery"
+    - python: pypy
+      env: INSTALL="Django>=1.6,<1.7 celery>=3.1,<3.2"
+
 
 install:
-  - pip install Django==$DJANGO_VERSION
+  - pip install $INSTALL
   - pip install -r requirements.txt
 
 

--- a/djcelery_email/backends.py
+++ b/djcelery_email/backends.py
@@ -1,6 +1,24 @@
+from django.conf import settings
 from django.core.mail.backends.base import BaseEmailBackend
 
-from djcelery_email.tasks import send_email
+from djcelery_email.tasks import send_emails
+
+
+def chunked(iterator, chunksize):
+    """
+    Yields items from 'iterator' in chunks of size 'chunksize'.
+
+    >>> list(chunked([1, 2, 3, 4, 5], chunksize=2))
+    [(1, 2), (3, 4), (5,)]
+    """
+    chunk = []
+    for idx, item in enumerate(iterator, 1):
+        chunk.append(item)
+        if idx % chunksize == 0:
+            yield chunk
+            chunk = []
+    if chunk:
+        yield chunk
 
 
 class CeleryEmailBackend(BaseEmailBackend):
@@ -8,9 +26,8 @@ class CeleryEmailBackend(BaseEmailBackend):
         super(CeleryEmailBackend, self).__init__(fail_silently)
         self.init_kwargs = kwargs
 
-    def send_messages(self, email_messages, **kwargs):
-        results = []
-        kwargs['_backend_init_kwargs'] = self.init_kwargs
-        for msg in email_messages:
-            results.append(send_email.delay(msg, **kwargs))
-        return results
+    def send_messages(self, email_messages):
+        result_tasks = []
+        for chunk in chunked(email_messages, settings.CELERY_EMAIL_CHUNK_SIZE):
+            result_tasks.append(send_emails.delay(chunk, self.init_kwargs))
+        return result_tasks

--- a/djcelery_email/conf.py
+++ b/djcelery_email/conf.py
@@ -1,0 +1,9 @@
+from appconf import AppConf
+
+class DjangoCeleryEmailAppConf(AppConf):
+    class Meta:
+        prefix = 'CELERY_EMAIL'
+
+    TASK_CONFIG = {}
+    BACKEND = 'django.core.mail.backends.smtp.EmailBackend'
+    CHUNK_SIZE = 10

--- a/djcelery_email/models.py
+++ b/djcelery_email/models.py
@@ -1,0 +1,1 @@
+import djcelery_email.conf

--- a/djcelery_email/models.py
+++ b/djcelery_email/models.py
@@ -1,1 +1,0 @@
-import djcelery_email.conf

--- a/djcelery_email/tasks.py
+++ b/djcelery_email/tasks.py
@@ -1,17 +1,19 @@
 from django.conf import settings
 from django.core.mail import get_connection
 
-from celery.task import task
+try:
+    from celery import shared_task
+except ImportError:
+    from celery.decorators import task as shared_task
 
 
-@task(name='djcelery_email_send_multiple', ignore_result=True,
-      **settings.CELERY_EMAIL_TASK_CONFIG)
+@shared_task(name='djcelery_email_send_multiple', ignore_result=True,
+             **settings.CELERY_EMAIL_TASK_CONFIG)
 def send_emails(messages, backend_kwargs):
     if hasattr(messages, 'from_email'):
         # backwards compatibility: looks like a EmailMessage object
         messages = [messages]
 
-    logger = send_email.get_logger()
     conn = get_connection(backend=settings.CELERY_EMAIL_BACKEND, **backend_kwargs)
 
     for message in messages:
@@ -28,3 +30,10 @@ def send_emails(messages, backend_kwargs):
 
 # backwards compatibility
 SendEmailTask = send_email = send_emails
+
+
+try:
+    from celery.utils.log import get_task_logger
+    logger = get_task_logger(__name__)
+except ImportError:
+    logger = send_emails.get_logger()

--- a/djcelery_email/tasks.py
+++ b/djcelery_email/tasks.py
@@ -4,32 +4,27 @@ from django.core.mail import get_connection
 from celery.task import task
 
 
-CONFIG = getattr(settings, 'CELERY_EMAIL_TASK_CONFIG', {})
-BACKEND = getattr(settings, 'CELERY_EMAIL_BACKEND',
-                  'django.core.mail.backends.smtp.EmailBackend')
-TASK_CONFIG = {
-    'name': 'djcelery_email_send',
-    'ignore_result': True,
-}
-TASK_CONFIG.update(CONFIG)
+@task(name='djcelery_email_send_multiple', ignore_result=True,
+      **settings.CELERY_EMAIL_TASK_CONFIG)
+def send_emails(messages, backend_kwargs):
+    if hasattr(messages, 'from_email'):
+        # backwards compatibility: looks like a EmailMessage object
+        messages = [messages]
 
-
-@task(**TASK_CONFIG)
-def send_email(message, **kwargs):
     logger = send_email.get_logger()
-    conn = get_connection(backend=BACKEND,
-                          **kwargs.pop('_backend_init_kwargs', {}))
-    try:
-        result = conn.send_messages([message])
-        logger.debug("Successfully sent email message to %r.", message.to)
-        return result
-    except Exception as e:
-        # catching all exceptions b/c it could be any number of things
-        # depending on the backend
-        logger.warning("Failed to send email message to %r, retrying.",
-                       message.to)
-        send_email.retry(exc=e)
+    conn = get_connection(backend=settings.CELERY_EMAIL_BACKEND, **backend_kwargs)
+
+    for message in messages:
+        try:
+            conn.send_messages([message])
+            logger.debug("Successfully sent email message to %r.", message.to)
+        except Exception as e:
+            # Not expecting any specific kind of exception here because it
+            # could be any number of things, depending on the backend
+            logger.warning("Failed to send email message to %r, retrying. (%r)",
+                           message.to, e)
+            send_emails.retry([[message], backend_kwargs], exc=e, throw=False)
 
 
-# backwards compat
-SendEmailTask = send_email
+# backwards compatibility
+SendEmailTask = send_email = send_emails

--- a/djcelery_email/tasks.py
+++ b/djcelery_email/tasks.py
@@ -9,8 +9,11 @@ except ImportError:
 import djcelery_email.conf  # Make sure our AppConf is loaded properly.
 
 
-@shared_task(name='djcelery_email_send_multiple', ignore_result=True,
-             **settings.CELERY_EMAIL_TASK_CONFIG)
+TASK_CONFIG = {'name': 'djcelery_email_send_multiple', 'ignore_result': True}
+TASK_CONFIG.update(settings.CELERY_EMAIL_TASK_CONFIG)
+
+
+@shared_task(**TASK_CONFIG)
 def send_emails(messages, backend_kwargs):
     if hasattr(messages, 'from_email'):
         # backwards compatibility: looks like a EmailMessage object

--- a/djcelery_email/tasks.py
+++ b/djcelery_email/tasks.py
@@ -6,6 +6,8 @@ try:
 except ImportError:
     from celery.decorators import task as shared_task
 
+import djcelery_email.conf  # Make sure our AppConf is loaded properly.
+
 
 @shared_task(name='djcelery_email_send_multiple', ignore_result=True,
              **settings.CELERY_EMAIL_TASK_CONFIG)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 Django>=1.4.0
 django-celery>=2.5.0
+django-appconf

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-Django>=1.4.0
-django-celery>=2.5.0
+Django
+celery>=2.3.0
 django-appconf

--- a/setup.py
+++ b/setup.py
@@ -57,6 +57,7 @@ setup(
     zip_safe=False,
     install_requires=[
         "django-celery>=2.2.0",
+        "django-appconf",
     ],
     cmdclass = {"test": RunTests},
     classifiers=[

--- a/setup.py
+++ b/setup.py
@@ -22,15 +22,12 @@ class RunTests(Command):
     def run(self):
         this_dir = os.getcwd()
         testproj_dir = os.path.join(this_dir, "test_project")
-        os.chdir(testproj_dir)
         sys.path.append(testproj_dir)
-        from django.core.management import execute_manager
-        os.environ["DJANGO_SETTINGS_MODULE"] = os.environ.get(
-                        "DJANGO_SETTINGS_MODULE", "settings")
-        settings_file = os.environ["DJANGO_SETTINGS_MODULE"]
-        settings_mod = __import__(settings_file, {}, {}, [''])
-        execute_manager(settings_mod, argv=[
-            __file__, "test"])
+
+        from django.core.management import execute_from_command_line
+        os.environ.setdefault("DJANGO_SETTINGS_MODULE", "settings")
+        os.chdir(testproj_dir)
+        execute_from_command_line([__file__, "test"])
         os.chdir(this_dir)
 
     def initialize_options(self):

--- a/setup.py
+++ b/setup.py
@@ -56,7 +56,8 @@ setup(
     scripts=[],
     zip_safe=False,
     install_requires=[
-        "django-celery>=2.2.0",
+        "django",
+        "celery>=2.3.0",
         "django-appconf",
     ],
     cmdclass = {"test": RunTests},

--- a/test_project/manage.py
+++ b/test_project/manage.py
@@ -1,11 +1,10 @@
 #!/usr/bin/env python
-from django.core.management import execute_manager
-try:
-    import settings # Assumed to be in the same directory.
-except ImportError:
-    import sys
-    sys.stderr.write("Error: Can't find the file 'settings.py' in the directory containing %r. It appears you've customized things.\nYou'll have to run django-admin.py, passing it your settings module.\n(If the file settings.py does indeed exist, it's causing an ImportError somehow.)\n" % __file__)
-    sys.exit(1)
+import os
+import sys
 
 if __name__ == "__main__":
-    execute_manager(settings)
+    os.environ.setdefault("DJANGO_SETTINGS_MODULE", "settings")
+
+    from django.core.management import execute_from_command_line
+
+    execute_from_command_line(sys.argv)

--- a/test_project/settings.py
+++ b/test_project/settings.py
@@ -12,23 +12,22 @@ DATABASES = {
 
 
 INSTALLED_APPS = (
-    'appconf',
-    'djcelery',
     'djcelery_email',
+    'appconf',
     'tester',
 )
 
 SECRET_KEY = 'unique snowflake'
 
 
-CELERY_EMAIL_BACKEND = 'django.core.mail.backends.locmem.EmailBackend'
 TEST_RUNNER = "test_runner.DJCETestSuiteRunner"
-CELERY_EMAIL_TASK_CONFIG = {
-    'queue' : 'django_email',
-    'delivery_mode' : 1, # non persistent
-    'rate_limit' : '50/m', # 50 emails per minute
-}
-BROKER_URL = 'memory://'
 
 # Not set here - see 'test_runner.py'
 # EMAIL_BACKEND = 'djcelery_email.backends.CeleryEmailBackend'
+
+CELERY_EMAIL_BACKEND = 'django.core.mail.backends.locmem.EmailBackend'
+CELERY_EMAIL_TASK_CONFIG = {
+    'queue' : 'django_email',
+    'delivery_mode' : 1, # non persistent
+    'rate_limit' : '50/m', # 50 chunks per minute
+}

--- a/test_project/settings.py
+++ b/test_project/settings.py
@@ -1,9 +1,5 @@
-import os.path
+import os
 import sys
-
-import djcelery
-
-djcelery.setup_loader()
 
 PROJECT_ROOT = os.path.abspath(os.path.dirname(__file__))
 sys.path.insert(0, os.path.join(PROJECT_ROOT, '..'))
@@ -11,14 +7,12 @@ sys.path.insert(0, os.path.join(PROJECT_ROOT, '..'))
 DATABASES = {
     'default': {
         'ENGINE': 'django.db.backends.sqlite3',
-        'NAME': os.path.join(PROJECT_ROOT, 'db.sqlite'),
     }
 }
 
 
-ROOT_URLCONF = 'test_project.urls'
-
 INSTALLED_APPS = (
+    'appconf',
     'djcelery',
     'djcelery_email',
     'tester',
@@ -26,14 +20,15 @@ INSTALLED_APPS = (
 
 SECRET_KEY = 'unique snowflake'
 
-TEST_RUNNER = "test_runner.DJCETestSuiteRunner"
 
-CELERY_ALWAYS_EAGER = True
 CELERY_EMAIL_BACKEND = 'django.core.mail.backends.locmem.EmailBackend'
-EMAIL_BACKEND = 'djcelery_email.backends.CeleryEmailBackend'
-# for tests
+TEST_RUNNER = "test_runner.DJCETestSuiteRunner"
 CELERY_EMAIL_TASK_CONFIG = {
     'queue' : 'django_email',
     'delivery_mode' : 1, # non persistent
     'rate_limit' : '50/m', # 50 emails per minute
 }
+BROKER_URL = 'memory://'
+
+# Not set here - see 'test_runner.py'
+# EMAIL_BACKEND = 'djcelery_email.backends.CeleryEmailBackend'

--- a/test_project/test_runner.py
+++ b/test_project/test_runner.py
@@ -4,5 +4,5 @@ from django.test.simple import DjangoTestSuiteRunner
 
 class DJCETestSuiteRunner(DjangoTestSuiteRunner):
     def setup_test_environment(self, **kwargs):
-        super(DjangoTestSuiteRunner, self).setup_test_environment(**kwargs)
+        super(DJCETestSuiteRunner, self).setup_test_environment(**kwargs)
         settings.EMAIL_BACKEND = 'djcelery_email.backends.CeleryEmailBackend'

--- a/test_project/test_runner.py
+++ b/test_project/test_runner.py
@@ -1,10 +1,8 @@
+from django.conf import settings
 from django.test.simple import DjangoTestSuiteRunner
 
 
 class DJCETestSuiteRunner(DjangoTestSuiteRunner):
     def setup_test_environment(self, **kwargs):
-        pass
-
-    def teardown_test_environment(self, **kwargs):
-        pass
-
+        super(DjangoTestSuiteRunner, self).setup_test_environment(**kwargs)
+        settings.EMAIL_BACKEND = 'djcelery_email.backends.CeleryEmailBackend'

--- a/test_project/tester/models.py
+++ b/test_project/tester/models.py
@@ -1,3 +1,0 @@
-from django.db import models
-
-# Create your models here.

--- a/test_project/tester/tests.py
+++ b/test_project/tester/tests.py
@@ -1,13 +1,14 @@
-from django.conf import settings
 from django.core import mail
 from django.core.mail.backends.base import BaseEmailBackend
 from django.test import TestCase
-from django.test.utils import override_settings
 from django.core.mail.backends import locmem
+try:
+    from django.test.utils import override_settings
+except ImportError:
+    from override_settings import override_settings
 
 import celery
-from djcelery_email.tasks import send_email, send_emails
-import djcelery_email
+from djcelery_email import tasks
 
 
 def even(n):
@@ -41,26 +42,26 @@ class TaskTests(TestCase):
     def test_send_single_email(self):
         """ It should accept and send a single EmailMessage object. """
         msg = mail.EmailMessage()
-        send_email(msg, backend_kwargs={})
+        tasks.send_email(msg, backend_kwargs={})
         self.assertEqual(len(mail.outbox), 1)
-        self.assertIs(msg, mail.outbox[0])
+        self.assertTrue(msg is mail.outbox[0])
 
     def test_send_multiple_emails(self):
         """ It should accept and send a list of EmailMessage objects. """
         N = 10
         msgs = [mail.EmailMessage() for i in range(N)]
-        send_emails(msgs, backend_kwargs={})
+        tasks.send_emails(msgs, backend_kwargs={})
 
         self.assertEqual(len(mail.outbox), N)
         for i in range(N):
-            self.assertIs(msgs[i], mail.outbox[i])
+            self.assertTrue(msgs[i] is mail.outbox[i])
 
     @override_settings(CELERY_EMAIL_BACKEND='tester.tests.TracingBackend')
     def test_uses_correct_backend(self):
         """ It should use the backend configured in CELERY_EMAIL_BACKEND. """
         TracingBackend.called = False
         msg = mail.EmailMessage()
-        send_emails(msg, backend_kwargs={})
+        tasks.send_emails(msg, backend_kwargs={})
         self.assertTrue(TracingBackend.called)
 
     @override_settings(CELERY_EMAIL_BACKEND='tester.tests.TracingBackend')
@@ -68,7 +69,7 @@ class TaskTests(TestCase):
         """ It should pass kwargs like username and password to the backend. """
         TracingBackend.kwargs = None
         msg = mail.EmailMessage()
-        send_emails(msg, backend_kwargs={'foo': 'bar'})
+        tasks.send_emails(msg, backend_kwargs={'foo': 'bar'})
         self.assertEqual(TracingBackend.kwargs.get('foo'), 'bar')
 
 
@@ -91,6 +92,7 @@ class TaskErrorTests(TestCase):
     Tests that the 'tasks.send_emails' task does not crash if a single message
     could not be sent and that it requeues that message.
     """
+    # TODO: replace setUp/tearDown with 'unittest.mock' at some point
     def setUp(self):
         super(TaskErrorTests, self).setUp()
 
@@ -98,19 +100,18 @@ class TaskErrorTests(TestCase):
         def mock_retry(*args, **kwargs):
             self._retry_calls.append((args, kwargs))
 
-        # TODO: replace with 'unittest.mock' at some point
-        self._old_retry = send_emails.retry
-        send_emails.retry = mock_retry
+        self._old_retry = tasks.send_emails.retry
+        tasks.send_emails.retry = mock_retry
 
     def tearDown(self):
         super(TaskErrorTests, self).tearDown()
-        send_emails.retry = self._old_retry
+        tasks.send_emails.retry = self._old_retry
 
     @override_settings(CELERY_EMAIL_BACKEND='tester.tests.EvenErrorBackend')
     def test_send_multiple_emails(self):
         N = 10
         msgs = [mail.EmailMessage(subject="msg %d" % i) for i in range(N)]
-        send_emails(msgs, backend_kwargs={'foo': 'bar'})
+        tasks.send_emails(msgs, backend_kwargs={'foo': 'bar'})
 
         # Assert that only "odd"/good messages have been sent.
         self.assertEqual(len(mail.outbox), 5)
@@ -126,7 +127,7 @@ class TaskErrorTests(TestCase):
         for msg, (args, kwargs) in zip(odd_msgs, self._retry_calls):
             retry_args = args[0]
             self.assertEqual(retry_args, [[msg], {'foo': 'bar'}])
-            self.assertIsInstance(kwargs.get('exc'), RuntimeError)
+            self.assertTrue(isinstance(kwargs.get('exc'), RuntimeError))
             self.assertFalse(kwargs.get('throw', True))
 
 
@@ -137,16 +138,31 @@ class BackendTests(TestCase):
     i.e. it submits the correct number of jobs (according to the chunk size)
     and passes backend parameters to the task.
     """
+    # TODO: replace setUp/tearDown with 'unittest.mock' at some point
+    def setUp(self):
+        super(BackendTests, self).setUp()
+
+        self._delay_calls = []
+        def mock_delay(*args, **kwargs):
+            self._delay_calls.append((args, kwargs))
+
+        self._old_delay = tasks.send_emails.delay
+        tasks.send_emails.delay = mock_delay
+
+    def tearDown(self):
+        super(BackendTests, self).tearDown()
+        tasks.send_emails.delay = self._old_delay
+
     def test_backend_parameters(self):
         """ Our backend should pass kwargs to the 'send_emails' task. """
         kwargs = {'auth_user': 'user', 'auth_password': 'pass'}
-        results = mail.send_mass_mail([
+        mail.send_mass_mail([
             ('test1', 'Testing with Celery! w00t!!', 'from@example.com', ['to@example.com']),
             ('test2', 'Testing with Celery! w00t!!', 'from@example.com', ['to@example.com'])
         ], **kwargs)
 
-        args = celery_queue_pop()['args']
-        self.assertEqual(len(args), 2)
+        self.assertEqual(len(self._delay_calls), 1)
+        args, kwargs = self._delay_calls[0]
         messages, backend_kwargs = args
         self.assertEqual(messages[0].subject, 'test1')
         self.assertEqual(messages[1].subject, 'test2')
@@ -167,14 +183,16 @@ class BackendTests(TestCase):
             ])
 
             num_chunks = 3  # floor(11.0 / 4.0)
-            queued_tasks = [celery_queue_pop() for i in range(num_chunks)]
-            full_tasks = queued_tasks[:-1]
-            last_task = queued_tasks[-1]
+            self.assertEqual(len(self._delay_calls), num_chunks)
 
-            for task in full_tasks:
-                self.assertEqual(len(task['args'][0]), chunksize)
+            full_tasks = self._delay_calls[:-1]
+            last_task = self._delay_calls[-1]
 
-            self.assertEqual(len(last_task['args'][0]), N % chunksize)
+            for args, kwargs in full_tasks:
+                self.assertEqual(len(args[0]), chunksize)
+
+            args, kwargs = last_task
+            self.assertEqual(len(args[0]), N % chunksize)
 
 
 class ConfigTests(TestCase):
@@ -183,13 +201,25 @@ class ConfigTests(TestCase):
     (those set in the CELERY_EMAIL_TASK_CONFIG setting)
     """
     def test_setting_extra_configs(self):
-        self.assertEqual(send_email.queue, 'django_email')
-        self.assertEqual(send_email.delivery_mode, 1)
-        self.assertEqual(send_email.rate_limit, '50/m')
+        self.assertEqual(tasks.send_email.queue, 'django_email')
+        self.assertEqual(tasks.send_email.delivery_mode, 1)
+        self.assertEqual(tasks.send_email.rate_limit, '50/m')
 
 
-@override_settings(CELERY_ALWAYS_EAGER=True)
 class IntegrationTests(TestCase):
+    # We run these tests in ALWAYS_EAGER mode, but they might as well be
+    # executed using a real backend (maybe we can add that to the test setup in
+    # the future?)
+
+    def setUp(self):
+        super(IntegrationTests, self).setUp()
+        # TODO: replace with 'unittest.mock' at some point
+        celery.current_app.conf.CELERY_ALWAYS_EAGER = True
+
+    def tearDown(self):
+        super(IntegrationTests, self).tearDown()
+        celery.current_app.conf.CELERY_ALWAYS_EAGER = False
+
     def test_sending_email(self):
         results = mail.send_mail('test', 'Testing with Celery! w00t!!', 'from@example.com',
                                  ['to@example.com'])

--- a/test_project/tester/tests.py
+++ b/test_project/tester/tests.py
@@ -2,22 +2,194 @@ from django.conf import settings
 from django.core import mail
 from django.core.mail.backends.base import BaseEmailBackend
 from django.test import TestCase
+from django.test.utils import override_settings
+from django.core.mail.backends import locmem
 
-from djcelery_email.tasks import send_email
+import celery
+from djcelery_email.tasks import send_email, send_emails
 import djcelery_email
 
 
-class TestBackend(BaseEmailBackend):
-    def __init__(self, username=None, password=None, fail_silently=False, **kwargs):
-        self.username = username
-        self.password = password
-
-    def send_messages(self, email_messages):
-        return {'username': self.username, 'password': self.password}
+def even(n):
+    return n % 2 == 0
 
 
-class DjangoCeleryEmailTests(TestCase):
+def celery_queue_pop():
+    """ Pops a single task from Celery's 'memory://' queue. """
+    with celery.current_app.connection() as conn:
+        queue = conn.SimpleQueue('django_email', no_ack=True)
+        return queue.get().payload
 
+
+class TracingBackend(BaseEmailBackend):
+    def __init__(self, **kwargs):
+        self.__class__.kwargs = kwargs
+
+    def send_messages(self, messages):
+        self.__class__.called = True
+
+
+class TaskTests(TestCase):
+    """
+    Tests that the 'tasks.send_email(s)' task works correctly:
+        - should accept a single or multiple messages
+        - should send all these messages
+        - should use the backend set in CELERY_EMAIL_BACKEND
+        - should pass the given kwargs to that backend
+        - should retry sending failed messages (see TaskErrorTests)
+    """
+    def test_send_single_email(self):
+        """ It should accept and send a single EmailMessage object. """
+        msg = mail.EmailMessage()
+        send_email(msg, backend_kwargs={})
+        self.assertEqual(len(mail.outbox), 1)
+        self.assertIs(msg, mail.outbox[0])
+
+    def test_send_multiple_emails(self):
+        """ It should accept and send a list of EmailMessage objects. """
+        N = 10
+        msgs = [mail.EmailMessage() for i in range(N)]
+        send_emails(msgs, backend_kwargs={})
+
+        self.assertEqual(len(mail.outbox), N)
+        for i in range(N):
+            self.assertIs(msgs[i], mail.outbox[i])
+
+    @override_settings(CELERY_EMAIL_BACKEND='tester.tests.TracingBackend')
+    def test_uses_correct_backend(self):
+        """ It should use the backend configured in CELERY_EMAIL_BACKEND. """
+        TracingBackend.called = False
+        msg = mail.EmailMessage()
+        send_emails(msg, backend_kwargs={})
+        self.assertTrue(TracingBackend.called)
+
+    @override_settings(CELERY_EMAIL_BACKEND='tester.tests.TracingBackend')
+    def test_backend_parameters(self):
+        """ It should pass kwargs like username and password to the backend. """
+        TracingBackend.kwargs = None
+        msg = mail.EmailMessage()
+        send_emails(msg, backend_kwargs={'foo': 'bar'})
+        self.assertEqual(TracingBackend.kwargs.get('foo'), 'bar')
+
+
+class EvenErrorBackend(locmem.EmailBackend):
+    """ Fails to deliver every 2nd message. """
+    def __init__(self, *args, **kwargs):
+        super(EvenErrorBackend, self).__init__(*args, **kwargs)
+        self.message_count = 0
+
+    def send_messages(self, messages):
+        self.message_count += 1
+        if even(self.message_count-1):
+            raise RuntimeError("Something went wrong sending the message")
+        else:
+            return super(EvenErrorBackend, self).send_messages(messages)
+
+
+class TaskErrorTests(TestCase):
+    """
+    Tests that the 'tasks.send_emails' task does not crash if a single message
+    could not be sent and that it requeues that message.
+    """
+    def setUp(self):
+        super(TaskErrorTests, self).setUp()
+
+        self._retry_calls = []
+        def mock_retry(*args, **kwargs):
+            self._retry_calls.append((args, kwargs))
+
+        # TODO: replace with 'unittest.mock' at some point
+        self._old_retry = send_emails.retry
+        send_emails.retry = mock_retry
+
+    def tearDown(self):
+        super(TaskErrorTests, self).tearDown()
+        send_emails.retry = self._old_retry
+
+    @override_settings(CELERY_EMAIL_BACKEND='tester.tests.EvenErrorBackend')
+    def test_send_multiple_emails(self):
+        N = 10
+        msgs = [mail.EmailMessage(subject="msg %d" % i) for i in range(N)]
+        send_emails(msgs, backend_kwargs={'foo': 'bar'})
+
+        # Assert that only "odd"/good messages have been sent.
+        self.assertEqual(len(mail.outbox), 5)
+        self.assertEqual(
+            [msg.subject for msg in mail.outbox],
+            ["msg 1", "msg 3", "msg 5", "msg 7", "msg 9"]
+        )
+
+        # Assert that "even"/bad messages have been requeued,
+        # one retry task per bad message.
+        self.assertEqual(len(self._retry_calls), 5)
+        odd_msgs = [msg for idx, msg in enumerate(msgs) if even(idx)]
+        for msg, (args, kwargs) in zip(odd_msgs, self._retry_calls):
+            retry_args = args[0]
+            self.assertEqual(retry_args, [[msg], {'foo': 'bar'}])
+            self.assertIsInstance(kwargs.get('exc'), RuntimeError)
+            self.assertFalse(kwargs.get('throw', True))
+
+
+
+class BackendTests(TestCase):
+    """
+    Tests that our *own* email backend ('backends.CeleryEmailBackend') works,
+    i.e. it submits the correct number of jobs (according to the chunk size)
+    and passes backend parameters to the task.
+    """
+    def test_backend_parameters(self):
+        """ Our backend should pass kwargs to the 'send_emails' task. """
+        kwargs = {'auth_user': 'user', 'auth_password': 'pass'}
+        results = mail.send_mass_mail([
+            ('test1', 'Testing with Celery! w00t!!', 'from@example.com', ['to@example.com']),
+            ('test2', 'Testing with Celery! w00t!!', 'from@example.com', ['to@example.com'])
+        ], **kwargs)
+
+        args = celery_queue_pop()['args']
+        self.assertEqual(len(args), 2)
+        messages, backend_kwargs = args
+        self.assertEqual(messages[0].subject, 'test1')
+        self.assertEqual(messages[1].subject, 'test2')
+        self.assertEqual(backend_kwargs, {'username': 'user', 'password': 'pass'})
+
+    def test_chunking(self):
+        """
+        Given 11 messages and a chunk size of 4, the backend should queue
+        11/4 = 3 jobs (2 jobs with 4 messages and 1 job with 3 messages).
+        """
+        N = 11
+        chunksize = 4
+
+        with override_settings(CELERY_EMAIL_CHUNK_SIZE=4):
+            mail.send_mass_mail([
+                ("subject", "body", "from@example.com", ["to@example.com"])
+                for _ in range(N)
+            ])
+
+            num_chunks = 3  # floor(11.0 / 4.0)
+            queued_tasks = [celery_queue_pop() for i in range(num_chunks)]
+            full_tasks = queued_tasks[:-1]
+            last_task = queued_tasks[-1]
+
+            for task in full_tasks:
+                self.assertEqual(len(task['args'][0]), chunksize)
+
+            self.assertEqual(len(last_task['args'][0]), N % chunksize)
+
+
+class ConfigTests(TestCase):
+    """
+    Tests that our Celery task has been initialized with the correct options
+    (those set in the CELERY_EMAIL_TASK_CONFIG setting)
+    """
+    def test_setting_extra_configs(self):
+        self.assertEqual(send_email.queue, 'django_email')
+        self.assertEqual(send_email.delivery_mode, 1)
+        self.assertEqual(send_email.rate_limit, '50/m')
+
+
+@override_settings(CELERY_ALWAYS_EAGER=True)
+class IntegrationTests(TestCase):
     def test_sending_email(self):
         results = mail.send_mail('test', 'Testing with Celery! w00t!!', 'from@example.com',
                                  ['to@example.com'])
@@ -34,24 +206,7 @@ class DjangoCeleryEmailTests(TestCase):
         results = mail.send_mass_mail(emails)
         for result in results:
             result.get()
+        self.assertEqual(len(results), 1)
         self.assertEqual(len(mail.outbox), 2)
-        self.assertEqual(len(results), 2)
         self.assertEqual(mail.outbox[0].subject, 'mass 1')
         self.assertEqual(mail.outbox[1].subject, 'mass 2')
-
-    def test_setting_extra_configs(self):
-        self.assertEqual(send_email.queue, 'django_email')
-        self.assertEqual(send_email.delivery_mode, 1)
-        self.assertEqual(send_email.rate_limit, '50/m')
-
-    def test_backend_parameters(self):
-        # Set test backend
-        default_backend = djcelery_email.tasks.BACKEND
-        djcelery_email.tasks.BACKEND = 'test_project.tester.tests.TestBackend'
-        # Actual test
-        results = mail.send_mail('test', 'Testing with Celery! w00t!!', 'from@example.com',
-                                 ['to@example.com'], auth_user='username', auth_password='password')
-        for result in results:
-            self.assertEqual(result.get(), {'username': 'username', 'password': 'password'})
-        # Restore backend
-        djcelery_email.tasks.BACKEND = default_backend


### PR DESCRIPTION
This fixes the use of the deprecated `execute_manager` (not available in Django 1.3 and 1.6+).

It also adds support for Travis -- if you haven't heard of Travis, check out http://about.travis-ci.org/docs/

You can then add this cool build badge to your README file: [![Build Status](https://travis-ci.org/jonashaag/django-celery-email.png?branch=master)](https://travis-ci.org/jonashaag/django-celery-email)

The latest commit also adds chunking and refactors the tests.

I'm sorry that the patch is so large, but it's all documented well and fully tested.

Tested on (see Travis): Django 1.2 to 1.6, Celery 2.3 to 3.1, Python 2.6 to 3.3 + PyPy