### PR TITLE
Support Celery's JSON serializer

### DIFF
--- a/djcelery_email/backends.py
+++ b/djcelery_email/backends.py
@@ -3,6 +3,18 @@ from django.core.mail.backends.base import BaseEmailBackend
 from djcelery_email.tasks import send_email
 
 
+def to_dict(message):
+    return {'subject': message.subject,
+            'body': message.body,
+            'from_email': message.from_email,
+            'to': message.to,
+            'bcc': message.bcc,
+            # ignore connection
+            'attachments': message.attachments,
+            'headers': message.extra_headers,
+            'cc': message.cc}
+
+
 class CeleryEmailBackend(BaseEmailBackend):
     def __init__(self, fail_silently=False, **kwargs):
         super(CeleryEmailBackend, self).__init__(fail_silently)
@@ -12,5 +24,5 @@ class CeleryEmailBackend(BaseEmailBackend):
         results = []
         kwargs['_backend_init_kwargs'] = self.init_kwargs
         for msg in email_messages:
-            results.append(send_email.delay(msg, **kwargs))
+            results.append(send_email.delay(to_dict(msg), **kwargs))
         return results

--- a/djcelery_email/tasks.py
+++ b/djcelery_email/tasks.py
@@ -31,7 +31,7 @@ def send_email(message, **kwargs):
         # catching all exceptions b/c it could be any number of things
         # depending on the backend
         logger.warning("Failed to send email message to %r, retrying.",
-                       message.to)
+                       message['to'])
         send_email.retry(exc=e)
 
 

--- a/djcelery_email/tasks.py
+++ b/djcelery_email/tasks.py
@@ -1,5 +1,5 @@
 from django.conf import settings
-from django.core.mail import get_connection
+from django.core.mail import get_connection, EmailMessage
 
 from celery.task import task
 
@@ -14,13 +14,17 @@ TASK_CONFIG = {
 TASK_CONFIG.update(CONFIG)
 
 
+def from_dict(messagedict):
+    return EmailMessage(**messagedict)
+
+
 @task(**TASK_CONFIG)
 def send_email(message, **kwargs):
     logger = send_email.get_logger()
     conn = get_connection(backend=BACKEND,
                           **kwargs.pop('_backend_init_kwargs', {}))
     try:
-        result = conn.send_messages([message])
+        result = conn.send_messages([from_dict(message)])
         logger.debug("Successfully sent email message to %r.", message.to)
         return result
     except Exception as e:

--- a/djcelery_email/tasks.py
+++ b/djcelery_email/tasks.py
@@ -25,7 +25,7 @@ def send_email(message, **kwargs):
                           **kwargs.pop('_backend_init_kwargs', {}))
     try:
         result = conn.send_messages([from_dict(message)])
-        logger.debug("Successfully sent email message to %r.", message.to)
+        logger.debug("Successfully sent email message to %r.", message['to'])
         return result
     except Exception as e:
         # catching all exceptions b/c it could be any number of things


### PR DESCRIPTION
This supports the use of Celery's JSON serializer, which [improves the security of Celery](http://celery.readthedocs.org/en/latest/userguide/security.html#serializers).

Prior to this patch, attempting to use Celery with the JSON serialization (as opposed to pickling) generated error messages complaining that a `django.core.mail.EmailMessage` is not JSON serializable. This patch converts email messages to dictionaries which are JSON serializable.

**For those still using the `pickle` serializer, everything should continue to work the same.**

### Caveat on JSON-serializing attachments

This patch copies the `attachments` property of EmailMessages without further processing. Per [https://docs.djangoproject.com/en/dev/topics/email/#emailmessage-objects](the Django docs on EmailMessage objects), attachments are:
> either `email.MIMEBase.MIMEBase instances`, or `(filename, content, mimetype)` triples.

As I understand it, this means that **attachments as `MIMEBase` instances will still fail**, but the triples may succeed. My application doesn't send attachments at the moment, so I haven't tested this. If in the deep distant future I get the opportunity to test it I will extend the patch.

**Attachments will still work for those using pickling.** In the mean time, this patch still enhances support for those using JSON - instead of everything failing, only a limited subset of things fail.