### PR TITLE
django-celery shouldn't be a dependency for this app

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 Django>=1.4.0
-django-celery>=2.5.0
+celery>=3.1.9

--- a/setup.py
+++ b/setup.py
@@ -59,7 +59,7 @@ setup(
     scripts=[],
     zip_safe=False,
     install_requires=[
-        "django-celery>=2.2.0",
+        'celery>=3.1.9',
     ],
     cmdclass = {"test": RunTests},
     classifiers=[


### PR DESCRIPTION
Replacing django-celery dependency with celery as it django-celery is no longer the preferred way to integrate celery into a django project -> https://celery.readthedocs.org/en/master/django/first-steps-with-django.html#using-celery-with-django
