### PR TITLE
Backward compat fixes for kwargs handling in send_email task.

### DIFF
--- a/djcelery_email/tasks.py
+++ b/djcelery_email/tasks.py
@@ -19,7 +19,11 @@ TASK_CONFIG.update(settings.CELERY_EMAIL_TASK_CONFIG)
 
 
 @shared_task(**TASK_CONFIG)
-def send_emails(messages, backend_kwargs):
+def send_emails(messages, backend_kwargs={}, **kwargs):
+    # backward compat: handle **kwargs and missing backend_kwargs
+    backend_kwargs = backend_kwargs.copy()  # Avoid modifying mutable default
+    backend_kwargs.update(kwargs)
+
     # backward compat: catch single object or dict
     if isinstance(messages, (EmailMessage, dict)):
         messages = [messages]

--- a/test_project/tester/tests.py
+++ b/test_project/tester/tests.py
@@ -51,6 +51,15 @@ class TaskTests(TestCase):
         # for JSONification and then back. Compare dicts instead.
         self.assertEqual(email_to_dict(msg), email_to_dict(mail.outbox[0]))
 
+    def test_send_single_email_object_no_backend_kwargs(self):
+        """ It should send email with backend_kwargs not provided. """
+        msg = mail.EmailMessage()
+        tasks.send_email(msg)
+        self.assertEqual(len(mail.outbox), 1)
+        # we can't compare them directly as it's converted into a dict
+        # for JSONification and then back. Compare dicts instead.
+        self.assertEqual(email_to_dict(msg), email_to_dict(mail.outbox[0]))
+
     def test_send_single_email_dict(self):
         """ It should accept and send a single EmailMessage dict. """
         msg = mail.EmailMessage()
@@ -95,6 +104,14 @@ class TaskTests(TestCase):
         TracingBackend.kwargs = None
         msg = mail.EmailMessage()
         tasks.send_email(email_to_dict(msg), backend_kwargs={'foo': 'bar'})
+        self.assertEqual(TracingBackend.kwargs.get('foo'), 'bar')
+
+    @override_settings(CELERY_EMAIL_BACKEND='tester.tests.TracingBackend')
+    def test_backend_parameters_kwargs(self):
+        """ It should pass on kwargs specified as keyword params. """
+        TracingBackend.kwargs = None
+        msg = mail.EmailMessage()
+        tasks.send_email(email_to_dict(msg), foo='bar')
         self.assertEqual(TracingBackend.kwargs.get('foo'), 'bar')
 
 


### PR DESCRIPTION
In version 1.1.0, `tasks.send_email()` requires the `backend_kwargs` parameter to be set explicitly. This breaks existing code using version 1.0.4 (the previous release on pypi) which uses `**kwargs` instead.

I've updated `send_emails()` to accept both mechanisms, but it may be cleaner to just remove the newer `backend_kwargs` param given that the release was so recent. (This could break code that's been using unreleased versions, though.)