### PR TITLE
HTML emails sent as text on retry

### DIFF
--- a/djcelery_email/utils.py
+++ b/djcelery_email/utils.py
@@ -54,4 +54,5 @@ def dict_to_email(messagedict):
         ret = EmailMessage(**messagedict)
     if content_subtype:
         ret.content_subtype = content_subtype
+        messagedict["content_subtype"] = content_subtype  # bring back content subtype for 'retry'
     return ret


### PR DESCRIPTION
*dict_to_email* method deletes content_subtype from messagedict:
```python
def dict_to_email(messagedict):
    if isinstance(messagedict, dict) and "content_subtype" in messagedict:
        content_subtype = messagedict["content_subtype"]
        del messagedict["content_subtype"]
    (...)
```

 Beacuse of that, if there is an exception when email is being sent, retry method is passed message dict without content_subtype information:
```python
try:
    sent = conn.send_messages([dict_to_email(message)])  # content_subtype removed (message is mutable)!
    (...)
except Exception as e:
    (...)
    send_emails.retry([[message], combined_kwargs], exc=e, throw=False)  # message  passed without content_subtype
```

This fix just adds content_subtype back to dict after EmailMessage is created