### PR TITLE
Add exception handling to celery backend connection

### DIFF
--- a/djcelery_email/tasks.py
+++ b/djcelery_email/tasks.py
@@ -44,7 +44,10 @@ def send_emails(messages, backend_kwargs=None, **kwargs):
     messages = [email_to_dict(m) for m in messages]
 
     conn = get_connection(backend=settings.CELERY_EMAIL_BACKEND, **combined_kwargs)
-    conn.open()
+    try:
+        conn.open()
+    except Exception:
+        logger.exception("Cannot reach CELERY_EMAIL_BACKEND %s", settings.CELERY_EMAIL_BACKEND)
 
     messages_sent = 0
 


### PR DESCRIPTION
This will allow celery email to be fault tolerant to connection issues with the celery email backend.

Catching a connection issues allows celery to retry failed tasks. If the connection error is not caught an exception will be raised before the retry logic.