### PR TITLE
Migrate to Celery 4.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,11 @@
 sudo: false
 language: python
-install: travis_retry pip install tox
+python:
+  - "2.7"
+  - "3.4"
+  - "3.5"
+  - "3.6"
+install: travis_retry pip install tox tox-travis
 script: tox
 deploy:
   provider: pypi

--- a/README.rst
+++ b/README.rst
@@ -15,11 +15,11 @@ of the messages.
 
 .. warning::
 
-	This version requres the following minimum versions:
+	This version requires the following versions:
 
-	* Python 2.7 and Python >= 3.3
-	* Django >= 1.7
-	* Celery 2.4
+	* Python 2.7 and Python >= 3.4
+	* Django 1.8, 1.10, 1.11
+	* Celery 4.0
 
 Using django-celery-email
 =========================
@@ -91,6 +91,12 @@ of their delivery.
 
 Changelog
 =========
+
+2.0
+---
+* Support for Django 1.11 and Celery 4.0
+* Dropped support for Celery 2.x and 3.x
+* Dropped support for Python 3.3
 
 1.1.5 - 2016.07.20
 ------------------

--- a/djcelery_email/__about__.py
+++ b/djcelery_email/__about__.py
@@ -7,7 +7,7 @@ __title__ = 'django-celery-email'
 __summary__ = 'An async Django email backend using celery'
 __uri__ = 'https://github.com/pmclanahan/django-celery-email'
 
-__version__ = '1.1.5'
+__version__ = '2.0.0'
 
 __author__ = 'Paul McLanahan'
 __email__ = 'paul@mclanahan.net'

--- a/djcelery_email/tasks.py
+++ b/djcelery_email/tasks.py
@@ -2,10 +2,7 @@ from django.conf import settings
 from django.core.mail import EmailMessage, get_connection
 from django.utils.six import string_types
 
-try:
-    from celery import shared_task
-except ImportError:
-    from celery.decorators import task as shared_task
+from celery import shared_task
 
 # Make sure our AppConf is loaded properly.
 import djcelery_email.conf  # noqa
@@ -20,11 +17,7 @@ TASK_CONFIG.update(settings.CELERY_EMAIL_TASK_CONFIG)
 
 # import base if string to allow a base celery task
 if 'base' in TASK_CONFIG and isinstance(TASK_CONFIG['base'], string_types):
-    try:
-        from django.utils.module_loading import import_string
-    except ImportError:
-        # 1.6
-        from django.utils.module_loading import import_by_path as import_string
+    from django.utils.module_loading import import_string
     TASK_CONFIG['base'] = import_string(TASK_CONFIG['base'])
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-Django>=1.7
-celery>=2.3.0
+Django>=1.8
+celery>=4.0
 django-appconf
 flake8
 twine

--- a/setup.py
+++ b/setup.py
@@ -30,8 +30,8 @@ setup(
     scripts=[],
     zip_safe=False,
     install_requires=[
-        'django>=1.7',
-        'celery>=2.3.0',
+        'django>=1.8',
+        'celery>=4.0',
         'django-appconf',
     ],
     classifiers=[
@@ -42,9 +42,9 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
         'Intended Audience :: Developers',
         'License :: OSI Approved :: BSD License',
         'Operating System :: POSIX',

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -324,11 +324,11 @@ class IntegrationTests(TestCase):
     def setUp(self):
         super(IntegrationTests, self).setUp()
         # TODO: replace with 'unittest.mock' at some point
-        celery.current_app.conf.CELERY_ALWAYS_EAGER = True
+        celery.current_app.conf.task_always_eager = True
 
     def tearDown(self):
         super(IntegrationTests, self).tearDown()
-        celery.current_app.conf.CELERY_ALWAYS_EAGER = False
+        celery.current_app.conf.task_always_eager = False
 
     def test_sending_email(self):
         [result] = mail.send_mail('test', 'Testing with Celery! w00t!!', 'from@example.com',

--- a/tox.ini
+++ b/tox.ini
@@ -1,18 +1,16 @@
 [tox]
 envlist =
-    py{27,33,py}-dj{17,18}-celery{24,30,31},
-    py{34,35}-dj18-celery31,
+    py{27,34,35,36}-dj{18,110,111}-celery{40},
     flake8
 skip_missing_interpreters = true
 
 [testenv]
 commands = ./runtests.py
 deps =
-    dj17: Django>=1.7,<1.8
     dj18: Django>=1.8,<1.9
-    celery24: celery>=2.4,<2.5
-    celery30: celery>=3.0,<3.1
-    celery31: celery>=3.1,<3.2
+    dj110: Django>=1.10,<1.11
+    dj111: Django>=1.11,<2.0
+    celery40: celery>=4.0,<4.1
 
 [testenv:flake8]
 deps = flake8


### PR DESCRIPTION
What was changed:
* added support for Django 1.10 and 1.11
* dropped support for Django 1.7 and Python 3.3 (Django >= 1.10 uses weakref.WeakMethod which was introducted in Python 3.4)
* added support for Celery 4.x, along with dropping support for Celery 2.x and 3.x
* tox-travis was added