### PR TITLE
Fix attachments with a "text/*" mimetype failing to be decoded.

### DIFF
--- a/tests/tests.py
+++ b/tests/tests.py
@@ -348,6 +348,17 @@ class IntegrationTests(TestCase):
         self.assertEqual(mail.outbox[0].subject, 'test')
         self.assertEqual(mail.outbox[0].alternatives, [(html, 'text/html')])
 
+    def test_sending_mail_with_text_attachment(self):
+        msg = mail.EmailMessage(
+            'test', 'Testing with Celery! w00t!!', 'from@example.com',
+            ['to@example.com'])
+        msg.attach('image.png', 'csv content', 'text/csv')
+        [result] = msg.send()
+        self.assertEqual(result.get(), 1)
+        self.assertEqual(len(mail.outbox), 1)
+        self.assertEqual(mail.outbox[0].subject, 'test')
+        self.assertEqual(mail.outbox[0].content_subtype, "plain")
+
     def test_sending_html_only_email(self):
         msg = mail.EmailMessage('test', 'Testing <b>with Celery! w00t!!</b>', 'from@example.com',
                                 ['to@example.com'])


### PR DESCRIPTION
For emails attachments contains a mimetype starting with `text/`, Django expects the content to be a string. This behavior is documented in here:

https://docs.djangoproject.com/en/2.0/topics/email/#emailmessage-objects

 This causes both the `email_to_dict` and `dict_to_email` function to fail. `email_to_dict` fails because the attachment returned by Django is a string and not bytes, and `dict_to_email` fails because Django itself complains if you try to send an email with a text/* mimetype and a binary content.

This causes the `a bytes-like object is required, not 'str'` error to be raised [at this line](https://github.com/pmclanahan/django-celery-email/blob/fbf027841caf0503bb1a0eb41338665a5cea2f5c/djcelery_email/utils.py#L60) 

I added workarounds to both functions and a regression test.