### PR TITLE
reduce memory usage when # of emails > chunk size

### DIFF
--- a/djcelery_email/backends.py
+++ b/djcelery_email/backends.py
@@ -12,7 +12,7 @@ class CeleryEmailBackend(BaseEmailBackend):
 
     def send_messages(self, email_messages):
         result_tasks = []
-        messages = [email_to_dict(msg) for msg in email_messages]
-        for chunk in chunked(messages, settings.CELERY_EMAIL_CHUNK_SIZE):
-            result_tasks.append(send_emails.delay(chunk, self.init_kwargs))
+        for chunk in chunked(email_messages, settings.CELERY_EMAIL_CHUNK_SIZE):
+            chunk_messages = [email_to_dict(msg) for msg in chunk]
+            result_tasks.append(send_emails.delay(chunk_messages, self.init_kwargs))
         return result_tasks


### PR DESCRIPTION
Currently `CeleryEmailBackend.send_messages` works like this:
1. All e-mails are serialized with `email_to_dict` and stored in a list
2. The list of serialized e-mails is split into chunks
3. A celery task is created for each chunk

Serializing all the e-mails at once can use lots of memory if you have lots of e-mails with attachments.

To improve memory efficiency, this PR changes `CeleryEmailBackend.send_messages` to run `email_to_dict` on one chunk of serialized e-mails at a time.

Benchmarks (on 80 emails with a 5 mb attachment):
* Before: 1028 mb (peak memory usage)
* After: 269 mb