### PR TITLE
fix TypeError that occures during messages sending

### DIFF
--- a/djcelery_email/tasks.py
+++ b/djcelery_email/tasks.py
@@ -47,7 +47,10 @@ def send_emails(messages, backend_kwargs=None, **kwargs):
         try:
             sent = conn.send_messages([dict_to_email(message)])
             if sent is not None:
-                messages_sent += sent
+                if isinstance(sent, list):
+                    messages_sent += len(sent)
+                else:
+                    messages_sent += sent
             logger.debug("Successfully sent email message to %r.", message['to'])
         except Exception as e:
             # Not expecting any specific kind of exception here because it


### PR DESCRIPTION
I encountered a TypeError error during sending messages, because it tried to add an integer and a list in tasks.py. I have been searching for the reason and found a little inconsistency with what Django's documentation suggests:

> This method (send_messages(email_messages)) receives a list of EmailMessage instances and returns the number of successfully delivered messages. 

So it looked like there was a problem in `CeleryEmailBackend.send_messages` in backends.py, but when i tried to fix that method and implement returning number of sent messages instead of a list with async results, several tests were failed as the result. Probably, it had had a side-effect for some other cases. So i decided to add a type checking in the tasks.py.