### PR TITLE
Issue 46: Attachments headers not working in 2.0.0

### DIFF
--- a/djcelery_email/utils.py
+++ b/djcelery_email/utils.py
@@ -51,13 +51,16 @@ def email_to_dict(message):
             filename = attachment.get_filename('')
             binary_contents = attachment.get_payload(decode=True)
             mimetype = attachment.get_content_type()
+            headers = dict(attachment._headers)
+            headers.pop('Content-Type', None)
         else:
             filename, binary_contents, mimetype = attachment
             # For a mimetype starting with text/, content is expected to be a string.
+            headers = None
             if isinstance(binary_contents, str):
                 binary_contents = binary_contents.encode()
         contents = base64.b64encode(binary_contents).decode('ascii')
-        message_dict['attachments'].append((filename, contents, mimetype))
+        message_dict['attachments'].append((filename, contents, mimetype, headers))
 
     if settings.CELERY_EMAIL_MESSAGE_EXTRA_ATTRIBUTES:
         for attr in settings.CELERY_EMAIL_MESSAGE_EXTRA_ATTRIBUTES:
@@ -82,21 +85,29 @@ def dict_to_email(messagedict):
 
     # remove attachments from message_kwargs then reinsert after base64 decoding
     attachments = message_kwargs.pop('attachments')
-    message_kwargs['attachments'] = []
+
+    if 'alternatives' in message_kwargs:
+        message = EmailMultiAlternatives(**message_kwargs)
+    else:
+        message = EmailMessage(**message_kwargs)
+
     for attachment in attachments:
-        filename, contents, mimetype = attachment
+        filename, contents, mimetype = attachment[:3]
+        # Headers are optional to support queued messages from previous versions
+        headers = attachment[3] if len(attachment) >= 3 else {}
         contents = base64.b64decode(contents.encode('ascii'))
 
         # For a mimetype starting with text/, content is expected to be a string.
         if mimetype and mimetype.startswith('text/'):
             contents = contents.decode()
 
-        message_kwargs['attachments'].append((filename, contents, mimetype))
-
-    if 'alternatives' in message_kwargs:
-        message = EmailMultiAlternatives(**message_kwargs)
-    else:
-        message = EmailMessage(**message_kwargs)
+        if headers is None:
+            message.attach(filename, contents, filename)
+        else:
+            mime_attachment = message._create_attachment(filename, contents, mimetype)
+            for name, value in headers.items():
+                mime_attachment.add_header(name, value)
+            message.attach(mime_attachment)
 
     # set attributes on message with items removed from message_kwargs earlier
     for attr, val in attributes_to_copy.items():

--- a/djcelery_email/utils.py
+++ b/djcelery_email/utils.py
@@ -102,7 +102,7 @@ def dict_to_email(messagedict):
             contents = contents.decode()
 
         if headers is None:
-            message.attach(filename, contents, filename)
+            message.attach(filename, contents, mimetype)
         else:
             mime_attachment = message._create_attachment(filename, contents, mimetype)
             for name, value in headers.items():

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -75,6 +75,18 @@ class UtilTests(TestCase):
         msg.attach(mimg)
         self.check_json_of_msg(msg)
 
+    def test_email_with_mime_attachment_headers(self):
+        file_path = os.path.join(os.path.dirname(__file__), 'image.png')
+        with open(file_path, 'rb') as file:
+            file_contents = file.read()
+        mimg = MIMEImage(file_contents)
+        mimg.add_header('X-Attachment-Id', 'attachment_id_test')
+        msg = mail.EmailMessage(
+            'test', 'Testing with Celery! w00t!!', 'from@example.com',
+            ['to@example.com'])
+        msg.attach(mimg)
+        self.check_json_of_msg(msg)
+
     def test_email_with_attachment_from_file(self):
         file_path = os.path.join(os.path.dirname(__file__), 'image.png')
         msg = mail.EmailMessage(


### PR DESCRIPTION
This pull request adds support for headers in attachments without breaking support for queued messages. A new value is added in the attachments tuple for headers.