### PR TITLE
Support for Celery 5 & Django 3.1-3.2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,8 @@ nosetests.xml
 .mr.developer.cfg
 .project
 .pydevproject
+
+# Python virtual environments
+.venv/
+env/
+venv/

--- a/README.rst
+++ b/README.rst
@@ -18,8 +18,8 @@ of the messages.
 	This version requires the following versions:
 
 	* Python >= 3.5
-	* Django 2.2, and 3.0
-	* Celery 4.0
+	* Django 2.2, 3.0, 3.1
+	* Celery >= 4.0
 
 Using django-celery-email
 =========================
@@ -91,6 +91,12 @@ of their delivery.
 
 Changelog
 =========
+
+3.1.0 - Unreleased
+------------------
+
+* Support for Django 3.1
+* Support for Celery 5
 
 3.0.0 - 2019.12.10
 ------------------

--- a/README.rst
+++ b/README.rst
@@ -18,7 +18,7 @@ of the messages.
 	This version requires the following versions:
 
 	* Python >= 3.5
-	* Django 2.2, 3.0, 3.1
+	* Django 2.2, 3.0, 3.1, 3.2
 	* Celery >= 4.0
 
 Using django-celery-email

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py{36,37,38}-dj{22,30}-celery{40,41,42,43},py35-dj22,
+    py{36,37,38}-dj{22,30,31}-celery{40,41,42,43,44,50,51},py35-dj22,
     flake8
 skip_missing_interpreters = true
 
@@ -9,10 +9,14 @@ commands = ./runtests.py
 deps =
     dj22: Django>=2.2,<2.3
     dj30: Django>=3.0,<3.1
+    dj31: Django>=3.1,<3.2
     celery40: celery>=4.0,<4.1
     celery41: celery>=4.1,<4.2
     celery42: celery>=4.2,<4.3
     celery43: celery>=4.3,<4.4
+    celery44: celery>=4.4,<4.5
+    celery50: celery>=5.0,<5.0.6
+    celery51: celery>=5.1,<5.2
 
 [testenv:flake8]
 deps = flake8

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py{36,37,38}-dj{22,30,31}-celery{40,41,42,43,44,50,51},py35-dj22,
+    py{36,37,38}-dj{22,30,31,32}-celery{40,41,42,43,44,50,51},py35-dj22,
     flake8
 skip_missing_interpreters = true
 
@@ -10,6 +10,7 @@ deps =
     dj22: Django>=2.2,<2.3
     dj30: Django>=3.0,<3.1
     dj31: Django>=3.1,<3.2
+    dj32: Django>=3.2,<3.3
     celery40: celery>=4.0,<4.1
     celery41: celery>=4.1,<4.2
     celery42: celery>=4.2,<4.3


### PR DESCRIPTION
## Description

This works add support and tests for Django 3.1-3.2 and Celery 5.0-5.1
There is no compatibility change in the latest version of Django, so nothing to change in the package itself.

Closes #80 #79 