### PR TITLE
Include test data in sdist

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,5 +2,5 @@ include README.rst
 include LICENSE
 include MANIFEST.in
 include requirements.txt
-recursive-include tests *.py
+graft tests
 recursive-include djcelery_email *.py


### PR DESCRIPTION
The sdist included the test suite only, but not the test data.