### PR TITLE
upgrade python versions

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -17,7 +17,7 @@ of the messages.
 
 	This version requires the following versions:
 
-	* Python >= 3.5
+	* Python >= 3.7
 	* Django 2.2, 3.0, 3.1, 3.2
 	* Celery >= 4.0
 

--- a/setup.py
+++ b/setup.py
@@ -37,6 +37,10 @@ setup(
     classifiers=[
         'Development Status :: 5 - Production/Stable',
         'Framework :: Django',
+        'Framework :: Django :: 2.2',
+        'Framework :: Django :: 3.0',
+        'Framework :: Django :: 3.1',
+        'Framework :: Django :: 3.2',
         'Operating System :: OS Independent',
         'Programming Language :: Python',
         'Programming Language :: Python :: 3',

--- a/setup.py
+++ b/setup.py
@@ -28,6 +28,7 @@ setup(
     packages=find_packages(exclude=['ez_setup', 'tests']),
     scripts=[],
     zip_safe=False,
+    python_requires='>=3.7',
     install_requires=[
         'django>=2.2',
         'celery>=4.0',
@@ -39,8 +40,6 @@ setup(
         'Operating System :: OS Independent',
         'Programming Language :: Python',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.5',
-        'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Intended Audience :: Developers',

--- a/setup.py
+++ b/setup.py
@@ -46,6 +46,7 @@ setup(
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
         'Intended Audience :: Developers',
         'License :: OSI Approved :: BSD License',
         'Operating System :: POSIX',

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py{36,37,38}-dj{22,30,31,32}-celery{40,41,42,43,44,50,51},py35-dj22,
+    py{37,38}-dj{22,30,31,32}-celery{40,41,42,43,44,50,51},
     flake8
 skip_missing_interpreters = true
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py{37,38}-dj{22,30,31,32}-celery{40,41,42,43,44,50,51},
+    py{37,38,39}-dj{22,30,31,32}-celery{40,41,42,43,44,50,51},
     flake8
 skip_missing_interpreters = true
 


### PR DESCRIPTION
python 3.6 is EOL since December 2021
Django versions 2.2, 3.0, 3.1 and 3.2 all support python 3.9
+ remove 3.5 and 3.6; add 3.9
+ added `python_requires='>=3.7'` to `setup.py`
+ update trove classifiers
+ updated `tox.ini`

this will be a breaking change for EOL python users


TODO:
changelog, versioning, release, etc