### PR TITLE
Migrate CI to GitHub actions

### DIFF
--- a/.github/workflows/flake8.yml
+++ b/.github/workflows/flake8.yml
@@ -1,5 +1,12 @@
 name: Run flake8
-on: [push]
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+
 jobs:
   flake8-lint:
     name: flake8

--- a/.github/workflows/flake8.yml
+++ b/.github/workflows/flake8.yml
@@ -1,7 +1,7 @@
 name: Run flake8
 on: [push]
 jobs:
-  tests:
+  flake8-lint:
     name: flake8
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/flake8.yml
+++ b/.github/workflows/flake8.yml
@@ -3,9 +3,11 @@ on:
   push:
     branches:
       - master
+      - main
   pull_request:
     branches:
       - master
+      - main
 
 jobs:
   flake8-lint:

--- a/.github/workflows/flake8.yml
+++ b/.github/workflows/flake8.yml
@@ -1,0 +1,21 @@
+name: Run flake8
+on: [push]
+jobs:
+  tests:
+    name: flake8
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out source code
+        uses: actions/checkout@v2
+
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: "3.9"
+          architecture: "x64"
+
+      - name: Install flake8
+        run: pip install flake8
+
+      - name: run flake8
+        run: flake8 . --max-line-length 120 --statistics --count --exclude  ".tox,.venv,.env,.git,__pycache__,docs,old,build,dist"

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -1,5 +1,12 @@
 name: Run tox
-on: [push]
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+
 jobs:
   tox-tests:
     runs-on: ubuntu-latest

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -1,0 +1,25 @@
+name: Run tox
+on: [push]
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: [3.7, 3.8, 3.9]
+    steps:
+      - name: Check out source code
+        uses: actions/checkout@v2
+
+      - name: Set up Python version ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install dependencies
+        run: |
+          pip install --upgrade pip wheel setuptools
+          pip install --upgrade tox tox-py
+
+      - name: Run tox targets for ${{ matrix.python-version }}
+        run: tox --py current

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -3,9 +3,11 @@ on:
   push:
     branches:
       - master
+      - main
   pull_request:
     branches:
       - master
+      - main
 
 jobs:
   tox-tests:

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -1,7 +1,7 @@
 name: Run tox
 on: [push]
 jobs:
-  tests:
+  tox-tests:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,6 @@
 [tox]
 envlist =
-    py{37,38,39}-dj{22,30,31,32}-celery{40,41,42,43,44,50,51},
-    flake8
+    py{37,38,39}-dj{22,30,31,32}-celery{40,41,42,43,44,50,51}
 skip_missing_interpreters = true
 
 [testenv]
@@ -18,10 +17,3 @@ deps =
     celery44: celery>=4.4,<4.5
     celery50: celery>=5.0,<5.0.6
     celery51: celery>=5.1,<5.2
-
-[testenv:flake8]
-deps = flake8
-commands = flake8 djcelery_email tests
-
-[flake8]
-max-line-length = 120


### PR DESCRIPTION
The pipelines on travis aren't operational

refer: https://travis-ci.org/github/pmclanahan/django-celery-email


Created Github actions workflows as replacement


- created workflow for running flake8
- created workflow for running tox
- removed flake8 from tox
- restrict workflows to run on push/pull-request to `master` or `main` branches only

TODO:
remove travis 
update build-passing badge on readme